### PR TITLE
Update Dockerfile to build in updated iot-edge & .NET Core environments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,8 @@ RUN  cd /iot-edge \
      --disable-native-remote-modules \
      --toolchain-file ./toolchain-rpi.cmake
 
+RUN dotnet publish /iot-edge/samples/dotnet_core_managed_gateway --runtime linux-arm
+
 #### Create IoT Edge for RPi tarball so that it is easy to copy the file from the Docker container to the host
 RUN tar -czf /iot-edge-rpi.tar.gz /iot-edge 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update
 RUN apt-get install -y dotnet-sdk-2.0.0
 
 #### Git clone IoT Edge repo
-RUN git clone https://github.com/Azure/iot-edge.git /iot-edge
+RUN git clone --branch 2017-08-21 https://github.com/Azure/iot-edge.git /iot-edge
 
 #### Update csproj files to target .NET Core 2.0.0
 RUN cd / \


### PR DESCRIPTION
1. The layout of the [iot-edge](https://github.com/Azure/iot-edge) repo has changed: everything has moved under a `v1/` folder. So this Dockerfile will fail to build. One fix would be to change the Dockerfile to handle the `v1/` folder, but then the iot-edge.tar.gz file that is hosted in Azure blob storage would also need to be updated. The simpler option is to clone the release of IoT Edge v1 that was available at the time this Dockerfile was created (tag: `2017-08-21`). That's the option I've taken for this PR.
2. I believe the .NET Core used to provide instructions for installing .NET Core 2.0 (preview) runtime directly to Raspberry Pi. But if that was the case, it's no longer true. As far as I can tell, the only supported way to install the runtime on the Pi _currently_ is to build an app on a supported dev platform (i.e., Windows, Linux, or macOS) and use `dotnet publish --runtime linux-arm` to publish a "self-contained app", which has the app and runtime binaries included together in the `publish/` folder (more info [here](https://github.com/dotnet/core/blob/master/samples/RaspberryPiInstructions.md)). You can then copy the publish folder to the Pi. So in this PR, I've included a `dotnet publish` step right before the tarball is created. The step only publishes the `dotnet_core_managed_gateway` sample, not others like `dotnet_core_module_sample`.